### PR TITLE
Add namestyle for local variables in the outermost scope `module_local_name_style`

### DIFF
--- a/CodeFormatCore/include/CodeFormatCore/Config/LuaDiagnosticStyle.h
+++ b/CodeFormatCore/include/CodeFormatCore/Config/LuaDiagnosticStyle.h
@@ -48,4 +48,6 @@ public:
     std::vector<NameStyleRule> const_variable_name_style = {
             NameStyleRule(NameStyleType::SnakeCase),
             NameStyleRule(NameStyleType::UpperSnakeCase)};
+
+    std::vector<NameStyleRule> module_local_name_style = {NameStyleRule(NameStyleType::SnakeCase)};
 };

--- a/CodeFormatCore/include/CodeFormatCore/Diagnostic/NameStyle/NameDefineType.h
+++ b/CodeFormatCore/include/CodeFormatCore/Diagnostic/NameStyle/NameDefineType.h
@@ -10,7 +10,8 @@ enum class NameDefineType {
     ImportModuleName,
     ModuleDefineName,
     TableFieldDefineName,
-    ConstVariableName
+    ConstVariableName,
+    ModuleLocalVariableName
 };
 
 struct NameStyleInfo {

--- a/CodeFormatCore/src/Config/LuaDiagnosticStyle.cpp
+++ b/CodeFormatCore/src/Config/LuaDiagnosticStyle.cpp
@@ -105,7 +105,8 @@ void LuaDiagnosticStyle::ParseTree(InfoTree &tree) {
             {module_name_style,          "module_name_style"         },
             {require_module_name_style,  "require_module_name_style" },
             {class_name_style,           "class_name_style"          },
-            {const_variable_name_style,  "const_variable_name_style" }
+            {const_variable_name_style,  "const_variable_name_style" },
+            {module_local_name_style,    "module_local_name_style"   }
     };
     for (auto &pair: name_styles) {
         if (auto n = root.GetValue(pair.second); !n.IsNull()) {
@@ -117,6 +118,20 @@ void LuaDiagnosticStyle::ParseTree(InfoTree &tree) {
             } else {
                 pair.first.push_back(MakeNameStyle(n));
             }
+        }
+    }
+    // module_local_name_style should fallback on local_name_style if not defined
+    if (root.GetValue("module_local_name_style").IsNull() && !root.GetValue("local_name_style").IsNull()) {
+        auto module_local_name_style_pair = std::find_if(name_styles.begin(), name_styles.end(), [&](const auto &pair) {
+            return pair.second == "module_local_name_style";
+        });
+        auto local_name_style_pair = std::find_if(name_styles.begin(), name_styles.end(), [&](const auto &pair) {
+            return pair.second == "local_name_style";
+        });
+
+        // overwrite the namestyle of module_local_name_style with the namestyle of local_name_style
+        if (module_local_name_style_pair != name_styles.end() && local_name_style_pair != name_styles.end()) {
+            module_local_name_style_pair->first = local_name_style_pair->first;
         }
     }
 }

--- a/CodeFormatCore/src/Diagnostic/NameStyle/NameStyleChecker.cpp
+++ b/CodeFormatCore/src/Diagnostic/NameStyle/NameStyleChecker.cpp
@@ -152,6 +152,12 @@ void NameStyleChecker::CheckInBody(LuaSyntaxNode &n, const LuaSyntaxTree &t) {
                             }
 
                             if (!matchConstRule) {
+                                // check for non-special, non-const variables that are in the outermost scope
+                                if (_scopeStack.size() == 1) {
+                                    PushStyleCheck(NameDefineType::ModuleLocalVariableName, name);
+                                    break;
+                                }
+
                                 PushStyleCheck(NameDefineType::LocalVariableName, name);
                             }
                         }
@@ -456,6 +462,15 @@ void NameStyleChecker::Diagnostic(DiagnosticBuilder &d, const LuaSyntaxTree &t) 
                                      n.GetTextRange(t),
                                      MakeDiagnosticInfo("ConstVariableName", n, t,
                                                         state.GetDiagnosticStyle().const_variable_name_style));
+                }
+                break;
+            }
+            case NameDefineType::ModuleLocalVariableName: {
+                if (!matcher.Match(n, t, state.GetDiagnosticStyle().module_local_name_style)) {
+                    d.PushDiagnostic(DiagnosticType::NameStyle,
+                                     n.GetTextRange(t),
+                                     MakeDiagnosticInfo("ModuleLocalVariableName", n, t,
+                                                        state.GetDiagnosticStyle().module_local_name_style));
                 }
                 break;
             }

--- a/docs/name_style.md
+++ b/docs/name_style.md
@@ -31,6 +31,7 @@
 * require_module_name_style
 * class_name_style
 * const_variable_name_style
+* module_local_name_style (没有额外作用域的变量，如果没有设置默认值，则将其默认值设置为 `local_name_style`)
 
 每一个可配置项的格式都是相同的, 每个可配置项可配置的值支持如下格式:
 * 单字符串 例如: 

--- a/docs/name_style_EN.md
+++ b/docs/name_style_EN.md
@@ -31,6 +31,7 @@ The configurable items are:
 * require_module_name_style
 * class_name_style
 * const_variable_name_style
+* module_local_name_style (variables without additional scope, setting defaults to the one of `local_name_style` if not set)
 
 The format of each configurable item is the same, and the configurable value of each configurable item supports the following formats:
 * Single string Example:


### PR DESCRIPTION
This PR introduces a new namestyle `module_local_name_style`, which allows to specifiy a separate namestyle for local variables, that have no scope except the outermost one.
This allows to force a different name style whenever local variables are not within e.g. a function for easier distinction.

It is applied when `local_name_style` would be applied, but the variable is in the outermost scope. To not change the behavior in existing configurations, the configuration falls back onto the configuration of `local_name_style` in case the `module_local_name_style` is not explicitly configured.

This namestyle is independent of the existing `module_name_style` and `require_module_name_style`.

_(Chinese documentation was translated from English using ChatGPT)_